### PR TITLE
Fix(temp): Fixed cap and Give addtitional Conquest points

### DIFF
--- a/src/server/game/Battlegrounds/Battleground.cpp
+++ b/src/server/game/Battlegrounds/Battleground.cpp
@@ -1177,6 +1177,7 @@ void Battleground::EndBattleground(uint32 winner)
                 player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_WIN_RATED_ARENA, rating ? rating : 1);
                 player->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_WIN_ARENA, GetMapId());
                 player->ModifyCurrency(CURRENCY_TYPE_CONQUEST_ARENA, sWorld->getIntConfig(CONFIG_CURRENCY_CONQUEST_POINTS_ARENA_REWARD));
+				player->ModifyCurrency(CURRENCY_TYPE_CONQUEST_POINTS, sWorld->getIntConfig(CONFIG_CURRENCY_CONQUEST_POINTS_ARENA_REWARD));
                 
                 // credit quest PVP
                 if ((player->GetQuestStatus(30576) == QUEST_STATUS_INCOMPLETE) || (player->GetQuestStatus(30577) == QUEST_STATUS_INCOMPLETE))

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -8164,7 +8164,7 @@ uint32 Player::GetCurrencyWeekCap(CurrencyTypesEntry const *currency, bool useRa
             break;
         }
 		//TODO: FIX that part, is temporal while fix conquest points calculation
-		cap = 3000;
+		cap = 3000 * CURRENCY_PRECISION;
         //cap = std::max(GetConquestWeekCap(arena), GetConquestWeekCap(rbg));
         break;
     }

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -8163,7 +8163,9 @@ uint32 Player::GetCurrencyWeekCap(CurrencyTypesEntry const *currency, bool useRa
             cap = GetConquestWeekCap(currency);
             break;
         }
-        cap = std::max(GetConquestWeekCap(arena), GetConquestWeekCap(rbg));
+		//TODO: FIX that part, is temporal while fix conquest points calculation
+		cap = 3000;
+        //cap = std::max(GetConquestWeekCap(arena), GetConquestWeekCap(rbg));
         break;
     }
     case CURRENCY_TYPE_CONQUEST_ARENA:


### PR DESCRIPTION
- Fixed Conquest points cap to 3000.
- Now the  BG's Gives additional 180 Conquest points to deal with Con quest points bug.